### PR TITLE
Require branch name when creating branch

### DIFF
--- a/bugs.sh
+++ b/bugs.sh
@@ -289,7 +289,11 @@ branch() {
     looks_like_jira_issue "$1"
     if [[ $? == 0 ]]; then
       branch_name=$1
-      if [[ $2 != "" ]]; then
+      if [[ $2 == "" ]]; then
+        echo "Please give a branch name"
+        echo "Usage: bugs branch <jira-issue> <branch-name>"
+        return 1
+      else
         whitespace_replaced=`echo $2 | sed 's/ /-/g'`
         branch_name="$branch_name/$whitespace_replaced"
       fi

--- a/test/test_bugs.sh
+++ b/test/test_bugs.sh
@@ -181,17 +181,11 @@ test_branch_whitespace() {
 
 test_branch_no_message() {
     ./bugs.sh branch "TEST-111" > /dev/null
-    assert_git_called_with "^checkout -b TEST-111$"
     success=$?
-    if [ $success -ne 0 ]; then
+    if [ $success -eq 0 ]; then
         return 1
     fi
-    assert_git_called_with "status"
-    success=$?
-    if [ $success -ne 0 ]; then
-        return 1
-    fi
-    return $?
+    return 0
 }
 
 


### PR DESCRIPTION
Require a branch name when creating a branch from an issue, instead of defaulting to an empty one.