### PR TITLE
Fix whitespace delimited args when rewriting args

### DIFF
--- a/bugs.sh
+++ b/bugs.sh
@@ -231,7 +231,6 @@ bug() {
     echo "Epic '$1' not found in $QUARTER_FILE"
     return 1
   fi
-  echo "Create bug in $EPIC"
   $JIRA_COMMAND issue create -tTask --parent "$EPIC" --summary "$2"
 }
 
@@ -429,7 +428,7 @@ if [[ $2 == "." ]]; then
   set -- $1 `best_ticket_for_folder $prefer_epic`
 elif [[ $1 == "." ]]; then
   # and open the epic
-  set -- `best_ticket_for_folder` $2
+  set -- `best_ticket_for_folder` "$2"
 fi
 
 

--- a/bugs.sh
+++ b/bugs.sh
@@ -231,6 +231,7 @@ bug() {
     echo "Epic '$1' not found in $QUARTER_FILE"
     return 1
   fi
+  echo "Create bug in $EPIC"
   $JIRA_COMMAND issue create -tTask --parent "$EPIC" --summary "$2"
 }
 

--- a/test/test_bugs.sh
+++ b/test/test_bugs.sh
@@ -323,6 +323,12 @@ test_make_new_bug() {
   return $?
 }
 
+test_make_new_bug_with_directory_shortcut() {
+  ./bugs.sh . "Do the thing" > /dev/null
+  assert_jira_called_with '^issue create -tTask --parent TEST-1236 --summary Do the thing'
+  return $?
+}
+
 # Kanban transitions
 
 test_kanban_start() {


### PR DESCRIPTION
It was noted that creating a bug under an epic only put the first word in the title of the bug. IE `bugs . "foo the bar" created an issue just named "foo". Since every bug title is pretty much quoted string, with spaces, this creates problems with weird bugs with single named issues.

This happens because when we get a shortcut or `.` as $1, we rewrite all the arguments. And we neglected to quote the $2 when doing so. This causes just the first word to be taken as $2

This fixes the issue (adding the quotes) and a corresponding test.
