### PR TITLE
Add duedate to output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 #Test files
 jira_mock
 editor_mock
+curl_mock
+jq_mock

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ brew install bugs
 
 [Get an API key, put it somewhere safe](https://github.com/ankitpokhrel/jira-cli#cloud-server).
 
-Put your key in ~/.netrc
+IMPORTANT - use the ~/.netrc file to store your credentials
 
 ```
 machine your_jira_server.atlassian.net


### PR DESCRIPTION
Display Epic metadata when viewing the epic (summary, etc)

- We want to get the duedate of an epic
- This doesn't seem easily accessible via the jira-cli tool when getting issue information
- We need to parse the .netrc file to get credentials, and then issue the curl ourselves to get issue details

This thus introduces the first direct access of the Jira API from the script.