### PR TITLE
Creates bugs on current folder if on issue branch

### DIFF
--- a/bugs.sh
+++ b/bugs.sh
@@ -351,11 +351,18 @@ view_issue() {
 }
 
 bug() {
-  EPIC=`epic_from_shortcut "$1"`
+  # Always try to get an epic
+  EPIC=$(epic_from_shortcut "$1")
   success=$?
   if [[ $success != 0 ]]; then
-    echo "Epic '$1' not found in $QUARTER_FILE"
-    return 1
+    echo "Epic '$1' not found in $QUARTER_FILE for $EPIC"
+    EPIC=$(best_ticket_for_folder "epic")
+    EPIC=$(epic_from_shortcut "$EPIC")
+    success=$?
+    if [[ $success != 0 ]]; then
+      echo "No epic found in $QUARTER_FILE for $PWD"
+      return 1
+    fi
   fi
   summary="$2"
   looks_like_command "$summary"
@@ -589,7 +596,6 @@ print_help() {
 # that shortcut, then it will use that epic when you do:
 #  bugs .
 if [[ $2 == "." ]]; then
-  # and open the epic
   prefer_epic=""
   # User explicitly wants an epic, dont use branch name
   if [[ $1 == "epic" ]]; then
@@ -597,7 +603,6 @@ if [[ $2 == "." ]]; then
   fi
   set -- $1 `best_ticket_for_folder $prefer_epic`
 elif [[ $1 == "." ]]; then
-  # and open the epic
   set -- `best_ticket_for_folder` "$2"
 fi
 

--- a/test/test_bugs.sh
+++ b/test/test_bugs.sh
@@ -401,6 +401,22 @@ test_make_new_bug() {
   return $?
 }
 
+test_make_new_bug_epic_shortcut() {
+  ./bugs.sh . "Do the thing" > /dev/null
+  assert_jira_called_with '^issue create -tTask --no-input --parent TEST-1236 --summary Do the thing'
+  return $?
+}
+
+test_make_new_bug_uses_folder_shortcut_on_branch() {
+  rev_parse_response='if [[ "$@" == "rev-parse --abbrev-ref HEAD" ]]; then
+    echo "TEST-9999/foo"
+  fi'
+  echo "$rev_parse_response" >> ./git_mock
+  ./bugs.sh . "Do the thing" > /dev/null
+  assert_jira_called_with '^issue create -tTask --no-input --parent TEST-1236 --summary Do the thing'
+  return $?
+}
+
 test_make_new_bug_empty_fails() {
   ./bugs.sh proj1 " " > /dev/null
   num_jira_commands=`wc -l < ./.last_jira_mock_args`


### PR DESCRIPTION
Previously when you ran the following on an issue branch (TEST-1234/foo-bar)

```
bugs . "a new bug title"
```

This would try to create a bug under "TEST-1234", which would fail, as its not an epic. When in reality you'd prefer the epic associated with the folder name. 

This uses the folder name's epic as the correct way to create an issue for ".".